### PR TITLE
Update link to specscdrom.pdf

### DIFF
--- a/README
+++ b/README
@@ -18,4 +18,4 @@ Relevant documentation:
 	ECMA 119:
 		http://www.ecma-international.org/publications/standards/Ecma-119.htm
 	"El Torito" Bootable CD-ROM Format Specification Version 1.0:
-		http://www.phoenix.com/NR/rdonlyres/98D3219C-9CC9-4DF5-B496-A286D893E36A/0/specscdrom.pdf
+		https://web.archive.org/web/20051104022221/http://www.phoenix.com/NR/rdonlyres/98D3219C-9CC9-4DF5-B496-A286D893E36A/0/specscdrom.pdf


### PR DESCRIPTION
Currently the link leads to a 404 page. Use a version archived on web.archive.org.